### PR TITLE
Lustre-client RPM's.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # lustre-boxes
 [![Circle CI](https://circleci.com/gh/tweag/lustre-boxes.svg?style=svg)](https://circleci.com/gh/tweag/lustre-boxes)
 
-A collection of Vagrant boxes including Lustre.
+A collection of Vagrant boxes including Lustre:
+
+* [lustre-client/centos7](lustre-client/centos7/README.md): a Centos
+  7 image with the Lustre client packages installed.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # lustre-boxes
+[![Circle CI](https://circleci.com/gh/tweag/lustre-boxes.svg?style=svg)](https://circleci.com/gh/tweag/lustre-boxes)
+
 A collection of Vagrant boxes including Lustre.

--- a/circle.yml
+++ b/circle.yml
@@ -13,3 +13,4 @@ test:
   override:
     - vagrant up --provider=docker:
         pwd: lustre-client/centos7
+        timeout: 1200

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  pre:
+    # XXX works better than ubuntu deb.
+    - curl https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4_x86_64.deb > /tmp/vagrant.deb
+    - sudo dpkg -i /tmp/vagrant.deb
+    - vagrant plugin install vagrant-librarian-puppet
+
+test:
+  override:
+    - vagrant up --provider=docker:
+        pwd: lustre-client/centos7

--- a/lustre-client/centos7/Dockerfile
+++ b/lustre-client/centos7/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:centos7
+
+RUN useradd --create-home --shell /bin/bash vagrant
+RUN echo root:vagrant | chpasswd
+RUN echo vagrant:vagrant | chpasswd
+
+ADD https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub /home/vagrant/.ssh/authorized_keys
+RUN chown -R vagrant:vagrant /home/vagrant/.ssh
+RUN chmod 0600 /home/vagrant/.ssh/authorized_keys
+RUN chmod 0700 /home/vagrant/.ssh
+
+RUN yum install -y openssh-server openssh-clients sudo wget curl
+RUN ssh-keygen -A
+
+ADD sudoers.d/01_vagrant /etc/sudoers.d/
+RUN chmod 0400 /etc/sudoers.d/01_vagrant
+
+RUN mkdir /var/run/sshd
+CMD ["/usr/sbin/sshd", "-D", "-e"]
+EXPOSE 22

--- a/lustre-client/centos7/Dockerfile
+++ b/lustre-client/centos7/Dockerfile
@@ -14,6 +14,8 @@ RUN ssh-keygen -A
 
 ADD sudoers.d/01_vagrant /etc/sudoers.d/
 RUN chmod 0400 /etc/sudoers.d/01_vagrant
+# Fix from https://github.com/docker/docker/issues/5663.
+RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_loginuid.so/' /etc/pam.d/sshd
 
 RUN mkdir /var/run/sshd
 CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/lustre-client/centos7/Puppetfile
+++ b/lustre-client/centos7/Puppetfile
@@ -1,0 +1,3 @@
+forge "https://forgeapi.puppetlabs.com"
+
+mod 'puppetlabs/vcsrepo'

--- a/lustre-client/centos7/README.md
+++ b/lustre-client/centos7/README.md
@@ -12,4 +12,10 @@ $ vagrant up
 $ vagrant ssh
 ```
 
-The generated RPM's and SRPM's can be found in `/root/rpmbuild/`.
+The generated RPM's and SRPM's can be found in `/root/rpmbuild/`. If
+you modify any of the provisioner files, you can conveniently
+reprovision without starting from scratch again using
+
+```
+$ vagrant reload --provision
+```

--- a/lustre-client/centos7/README.md
+++ b/lustre-client/centos7/README.md
@@ -12,6 +12,12 @@ $ vagrant up
 $ vagrant ssh
 ```
 
+You can use Docker as a provider instead of the default VirtualBox:
+
+```
+$ vagrant up --provider=docker
+```
+
 The generated RPM's and SRPM's can be found in `/root/rpmbuild/`. If
 you modify any of the provisioner files, you can conveniently
 reprovision without starting from scratch again using

--- a/lustre-client/centos7/README.md
+++ b/lustre-client/centos7/README.md
@@ -1,0 +1,15 @@
+# lustre-client CentOS image
+
+The configuration in this folder builds the lustre-client set of RPM's
+and installs them on top of a CentOS 7 base image. The RPM's are
+compiled to match the latest version of the kernel.
+
+# Usage
+
+```
+$ vagrant plugin install vagrant-librarian-puppet
+$ vagrant up
+$ vagrant ssh
+```
+
+The generated RPM's and SRPM's can be found in `/root/rpmbuild/`.

--- a/lustre-client/centos7/Vagrantfile
+++ b/lustre-client/centos7/Vagrantfile
@@ -2,10 +2,17 @@ VAGRANT_API_VERSION = 2
 
 Vagrant.configure(VAGRANT_API_VERSION) do |config|
   config.vm.box = "bento/centos-7.1"
+  config.vm.provider "docker" do |docker, override|
+    override.vm.box = nil
+    docker.build_dir = "."
+    docker.has_ssh = true
+  end
+
   config.vm.provision "shell", inline: "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm || true"
   config.vm.provision "shell", inline: "yum -y install puppet"
   config.vm.provision "puppet" do |puppet|
     puppet.module_path = "modules"
   end
   config.librarian_puppet.placeholder_filename = ".gitkeep"
+  config.ssh.pty = true
 end

--- a/lustre-client/centos7/Vagrantfile
+++ b/lustre-client/centos7/Vagrantfile
@@ -1,0 +1,11 @@
+VAGRANT_API_VERSION = 2
+
+Vagrant.configure(VAGRANT_API_VERSION) do |config|
+  config.vm.box = "bento/centos-7.1"
+  config.vm.provision "shell", inline: "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm || true"
+  config.vm.provision "shell", inline: "yum -y install puppet"
+  config.vm.provision "puppet" do |puppet|
+    puppet.module_path = "modules"
+  end
+  config.librarian_puppet.placeholder_filename = ".gitkeep"
+end

--- a/lustre-client/centos7/manifests/default.pp
+++ b/lustre-client/centos7/manifests/default.pp
@@ -48,6 +48,5 @@ exec { 'build-lustre-rpms':
 exec { 'install-lustre-rpms':
   command => 'yum install -y /root/rpmbuild/RPMS/x86_64/*.rpm',
   path => "/bin:/usr/bin",
-  require => Exec['build-lustre-rpms'],
+  require => [Exec['build-lustre-rpms'], Package['kernel']],
 }
-

--- a/lustre-client/centos7/manifests/default.pp
+++ b/lustre-client/centos7/manifests/default.pp
@@ -1,0 +1,41 @@
+vcsrepo { "/root/lustre.git":
+  ensure => present,
+  provider => git,
+  source => 'git://git.hpdd.intel.com/fs/lustre-release.git',
+  revision => '2.7.0',
+}
+
+package { 'python-docutils':
+  ensure => present,
+}
+
+package { 'libselinux-devel':
+  ensure => present,
+}
+
+exec { 'development-tools':
+  unless  => '/usr/bin/yum grouplist "Development tools" | /bin/grep "^Installed Groups"',
+  command => '/usr/bin/yum -y groupinstall "Development tools"',
+}
+
+exec { 'configure-lustre-spec':
+  command => 'sh autogen.sh &&
+              ./configure --with-linux=/usr/src/kernels/$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-devel)/',
+  creates => "/root/lustre.git/lustre.spec",
+  cwd => "/root/lustre.git",
+  path => "/bin:/usr/bin",
+  require => [Vcsrepo["/root/lustre.git"],
+              Package['python-docutils'],
+              Exec['development-tools']],
+}
+
+exec { 'build-lustre-rpm':
+  command => 'make rpms',
+  cwd => "/root/lustre.git",
+  path => "/bin:/usr/bin",
+  require => [Vcsrepo["/root/lustre.git"],
+              Package['libselinux-devel'],
+              Exec['configure-lustre-spec']],
+  timeout => 0,
+}
+

--- a/lustre-client/centos7/manifests/default.pp
+++ b/lustre-client/centos7/manifests/default.pp
@@ -36,6 +36,8 @@ exec { 'configure-lustre-spec':
 exec { 'build-lustre-rpms':
   command => 'make rpms',
   cwd => "/root/lustre.git",
+  environment => ["HOME=/root"],
+  logoutput => true,
   path => "/bin:/usr/bin",
   require => [Vcsrepo["/root/lustre.git"],
               Package['libselinux-devel'],
@@ -44,7 +46,7 @@ exec { 'build-lustre-rpms':
 }
 
 exec { 'install-lustre-rpms':
-  command => 'rpm -i /root/rpmbuild/RPMS/*.rpm',
+  command => 'yum install -y /root/rpmbuild/RPMS/x86_64/*.rpm',
   path => "/bin:/usr/bin",
   require => Exec['build-lustre-rpms'],
 }

--- a/lustre-client/centos7/manifests/default.pp
+++ b/lustre-client/centos7/manifests/default.pp
@@ -29,7 +29,7 @@ exec { 'configure-lustre-spec':
               Exec['development-tools']],
 }
 
-exec { 'build-lustre-rpm':
+exec { 'build-lustre-rpms':
   command => 'make rpms',
   cwd => "/root/lustre.git",
   path => "/bin:/usr/bin",
@@ -37,5 +37,11 @@ exec { 'build-lustre-rpm':
               Package['libselinux-devel'],
               Exec['configure-lustre-spec']],
   timeout => 0,
+}
+
+exec { 'install-lustre-rpms':
+  command => 'rpm -i /root/rpmbuild/RPMS/*.rpm',
+  path => "/bin:/usr/bin",
+  require => Exec['build-lustre-rpms'],
 }
 

--- a/lustre-client/centos7/manifests/default.pp
+++ b/lustre-client/centos7/manifests/default.pp
@@ -13,6 +13,10 @@ package { 'libselinux-devel':
   ensure => present,
 }
 
+package { 'kernel':
+  ensure => latest
+}
+
 exec { 'development-tools':
   unless  => '/usr/bin/yum grouplist "Development tools" | /bin/grep "^Installed Groups"',
   command => '/usr/bin/yum -y groupinstall "Development tools"',

--- a/lustre-client/centos7/sudoers.d/01_vagrant
+++ b/lustre-client/centos7/sudoers.d/01_vagrant
@@ -1,0 +1,1 @@
+vagrant ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
This PR provides a means to generate RPM's for installing the client
portion of Lustre on a base CentOS 7 system. Because CentOS keeps on
updating its kernels, and because older kernel versions are hard to
come by (e.g. most providers these days don't even carry CentOS 7.0,
only 7.1), we build Lustre from source to obtain a set of RPM's that
matches exactly that of the installed kernel.

This is done inside a Vagrant powered virtual machine. Once the RPM's
are built, you can copy them off to somewhere else using `scp`.
